### PR TITLE
Upcoming Demo Modifications

### DIFF
--- a/ros/launch/object_detector.launch
+++ b/ros/launch/object_detector.launch
@@ -7,7 +7,7 @@
     <!-- <arg name="output_dir_path" default="$(find eurobin_perception)/output_data"/> -->
     <arg name="output_dir_path" default="/tmp"/>
     <arg name="confidence_threshold" default="0.7"/>
-    <arg name="run_on_trigger" default="false"/>
+    <arg name="run_on_ros_trigger" default="false"/>
     <arg name="run_on_udp_trigger" default="true"/>
     <arg name="udp_ip" default="localhost"/>
     <arg name="udp_port" default="8000"/>
@@ -27,7 +27,7 @@
         <param name="dataset_dir_path" type="str" value="$(arg dataset_dir_path)"/>
         <param name="output_dir_path" type="str" value="$(arg output_dir_path)"/>
         <param name="confidence_threshold" type="double" value="$(arg confidence_threshold)"/>
-        <param name="run_on_trigger" type="bool" value="$(arg run_on_trigger)"/>
+        <param name="run_on_ros_trigger" type="bool" value="$(arg run_on_ros_trigger)"/>
         <param name="run_on_udp_trigger" type="bool" value="$(arg run_on_udp_trigger)"/>
         <param name="udp_ip" type="str" value="$(arg udp_ip)"/>
         <param name="udp_port" type="int" value="$(arg udp_port)"/>

--- a/ros/launch/object_detector.launch
+++ b/ros/launch/object_detector.launch
@@ -10,7 +10,7 @@
     <arg name="run_on_ros_trigger" default="false"/>
     <arg name="run_on_udp_trigger" default="true"/>
     <arg name="udp_ip" default="localhost"/>
-    <arg name="udp_trigger_port" default="6000"/>
+    <arg name="udp_trigger_port" default="5000"/>
     <arg name="image_topic" default="/camera/color/image_raw"/>
     <arg name="trigger_topic" default="/eurobin_perception/detector_trigger"/>
     <arg name="image_pub_topic" default="/eurobin_perception/detection_images"/>

--- a/ros/launch/object_detector.launch
+++ b/ros/launch/object_detector.launch
@@ -8,6 +8,9 @@
     <arg name="output_dir_path" default="/tmp"/>
     <arg name="confidence_threshold" default="0.7"/>
     <arg name="run_on_trigger" default="false"/>
+    <arg name="run_on_udp_trigger" default="true"/>
+    <arg name="udp_ip" default="localhost"/>
+    <arg name="udp_port" default="8000"/>
     <arg name="image_topic" default="/camera/color/image_raw"/>
     <arg name="trigger_topic" default="/eurobin_perception/detector_trigger"/>
     <arg name="image_pub_topic" default="/eurobin_perception/detection_images"/>
@@ -25,6 +28,9 @@
         <param name="output_dir_path" type="str" value="$(arg output_dir_path)"/>
         <param name="confidence_threshold" type="double" value="$(arg confidence_threshold)"/>
         <param name="run_on_trigger" type="bool" value="$(arg run_on_trigger)"/>
+        <param name="run_on_udp_trigger" type="bool" value="$(arg run_on_udp_trigger)"/>
+        <param name="udp_ip" type="str" value="$(arg udp_ip)"/>
+        <param name="udp_port" type="int" value="$(arg udp_port)"/>
         <param name="image_topic" type="str" value="$(arg image_topic)"/>
         <param name="trigger_topic" type="str" value="$(arg trigger_topic)"/>
         <param name="image_pub_topic" type="str" value="$(arg image_pub_topic)"/>

--- a/ros/launch/object_detector.launch
+++ b/ros/launch/object_detector.launch
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<launch>
+
+    <arg name="model_weights_file_path" default="$(find eurobin_perception)/models/tb_fasterrcnn_epochs_25_batches_1_tv_ratio_07_seed_2_20240121_154144.pt"/>
+    <arg name="class_colors_file_path" default="$(find eurobin_perception)/config/class_colors_taskboard.yaml"/>
+    <arg name="dataset_dir_path" default="/home/ahmed/tum/workspace/euRobin/detection_task/dataset"/>
+    <!-- <arg name="output_dir_path" default="$(find eurobin_perception)/output_data"/> -->
+    <arg name="output_dir_path" default="/tmp"/>
+    <arg name="confidence_threshold" default="0.7"/>
+    <arg name="run_on_trigger" default="false"/>
+    <arg name="image_topic" default="/camera/color/image_raw"/>
+    <arg name="trigger_topic" default="/eurobin_perception/detector_trigger"/>
+    <arg name="image_pub_topic" default="/eurobin_perception/detection_images"/>
+    <arg name="input_image_pub_topic" default="/eurobin_perception/input_images"/>
+    <arg name="detection_pub_topic" default="/eurobin_perception/detection_result"/>
+    <arg name="publish_visual_output" default="true"/>
+    <arg name="save_output" default="false"/>
+    <arg name="device" default="cpu"/>
+
+    <node pkg="eurobin_perception" type="continuous_cnn_detector_node" name="cnn_detector"
+        output="screen" respawn="false">
+        <param name="model_weights_file_path" type="str" value="$(arg model_weights_file_path)"/>
+        <param name="class_colors_file_path" type="str" value="$(arg class_colors_file_path)"/>
+        <param name="dataset_dir_path" type="str" value="$(arg dataset_dir_path)"/>
+        <param name="output_dir_path" type="str" value="$(arg output_dir_path)"/>
+        <param name="confidence_threshold" type="double" value="$(arg confidence_threshold)"/>
+        <param name="run_on_trigger" type="bool" value="$(arg run_on_trigger)"/>
+        <param name="image_topic" type="str" value="$(arg image_topic)"/>
+        <param name="trigger_topic" type="str" value="$(arg trigger_topic)"/>
+        <param name="image_pub_topic" type="str" value="$(arg image_pub_topic)"/>
+        <param name="input_image_pub_topic" type="str" value="$(arg input_image_pub_topic)"/>
+        <param name="detection_pub_topic" type="str" value="$(arg detection_pub_topic)"/>
+        <param name="publish_visual_output" type="bool" value="$(arg publish_visual_output)"/>
+        <param name="save_output" type="bool" value="$(arg save_output)"/>
+        <param name="device" type="str" value="$(arg device)"/>
+    </node>
+
+</launch>

--- a/ros/launch/object_detector.launch
+++ b/ros/launch/object_detector.launch
@@ -10,7 +10,7 @@
     <arg name="run_on_ros_trigger" default="false"/>
     <arg name="run_on_udp_trigger" default="true"/>
     <arg name="udp_ip" default="localhost"/>
-    <arg name="udp_port" default="8000"/>
+    <arg name="udp_trigger_port" default="6000"/>
     <arg name="image_topic" default="/camera/color/image_raw"/>
     <arg name="trigger_topic" default="/eurobin_perception/detector_trigger"/>
     <arg name="image_pub_topic" default="/eurobin_perception/detection_images"/>
@@ -30,7 +30,7 @@
         <param name="run_on_ros_trigger" type="bool" value="$(arg run_on_ros_trigger)"/>
         <param name="run_on_udp_trigger" type="bool" value="$(arg run_on_udp_trigger)"/>
         <param name="udp_ip" type="str" value="$(arg udp_ip)"/>
-        <param name="udp_port" type="int" value="$(arg udp_port)"/>
+        <param name="udp_trigger_port" type="int" value="$(arg udp_trigger_port)"/>
         <param name="image_topic" type="str" value="$(arg image_topic)"/>
         <param name="trigger_topic" type="str" value="$(arg trigger_topic)"/>
         <param name="image_pub_topic" type="str" value="$(arg image_pub_topic)"/>

--- a/ros/launch/pose_estimator.launch
+++ b/ros/launch/pose_estimator.launch
@@ -5,6 +5,8 @@
     <arg name="taskboard_frame_name" default="taskboard_frame"/>
     <arg name="num_retries" default="3"/>
     <arg name="output_dir_path" default="$(find eurobin_perception)/output_data"/>
+    <arg name="udp_ip" default="localhost"/>
+    <arg name="udp_output_port" default="6000"/>
     <arg name="point_cloud_topic" default="/camerka/depth/color/points"/>
     <arg name="camera_info_topic" default="/camera/color/camera_info"/>
     <arg name="detector_result_topic" default="/eurobin_perception/detection_result"/>
@@ -20,6 +22,8 @@
         <param name="taskboard_frame_name" type="str" value="$(arg taskboard_frame_name)"/>
         <param name="num_retries" type="int" value="$(arg num_retries)"/>
         <param name="output_dir_path" type="str" value="$(arg output_dir_path)"/>
+        <param name="udp_ip" type="str" value="$(arg udp_ip)"/>
+        <param name="udp_output_port" type="int" value="$(arg udp_output_port)"/>
         <param name="point_cloud_topic" type="str" value="$(arg point_cloud_topic)"/>
         <param name="camera_info_topic" type="str" value="$(arg camera_info_topic)"/>
         <param name="detector_result_topic" type="str" value="$(arg detector_result_topic)"/>

--- a/ros/launch/pose_estimator.launch
+++ b/ros/launch/pose_estimator.launch
@@ -10,7 +10,8 @@
     <arg name="point_cloud_topic" default="/camerka/depth/color/points"/>
     <arg name="camera_info_topic" default="/camera/color/camera_info"/>
     <arg name="detector_result_topic" default="/eurobin_perception/detection_result"/>
-    <arg name="object_list_pub_topic" default="/eurobin_perception/object_positions"/>
+    <arg name="object_positions_pub_topic" default="/eurobin_perception/object_positions"/>
+    <arg name="object_poses_pub_topic" default="/eurobin_perception/object_poses"/>
     <arg name="object_marker_pub_topic" default="/eurobin_perception/object_markers"/>
     <arg name="cropped_pc_pub_topic" default="/eurobin_perception/cropped_pc"/>
     <arg name="save_output" default="false"/>
@@ -27,7 +28,8 @@
         <param name="point_cloud_topic" type="str" value="$(arg point_cloud_topic)"/>
         <param name="camera_info_topic" type="str" value="$(arg camera_info_topic)"/>
         <param name="detector_result_topic" type="str" value="$(arg detector_result_topic)"/>
-        <param name="object_list_pub_topic" type="str" value="$(arg object_list_pub_topic)"/>
+        <param name="object_positions_pub_topic" type="str" value="$(arg object_positions_pub_topic)"/>
+        <param name="object_poses_pub_topic" type="str" value="$(arg object_poses_pub_topic)"/>
         <param name="object_marker_pub_topic" type="str" value="$(arg object_marker_pub_topic)"/>
         <param name="cropped_pc_pub_topic" type="str" value="$(arg cropped_pc_pub_topic)"/>
         <param name="save_output" type="bool" value="$(arg save_output)"/>

--- a/ros/scripts/continuous_cnn_detector_node
+++ b/ros/scripts/continuous_cnn_detector_node
@@ -9,6 +9,7 @@ Optionally runs the detector only after a ROS/UDP trigger message.
 import os
 import sys
 import time
+import signal
 import pickle
 import datetime
 
@@ -73,7 +74,8 @@ if __name__ == '__main__':
                                           '/eurobin_perception/detection_result')
 
     image_subscriber = rospy.Subscriber(image_topic, Image, image_callback)
-    trigger_subscriber = rospy.Subscriber(trigger_topic, Bool, trigger_callback)
+    if run_on_trigger:
+        trigger_subscriber = rospy.Subscriber(trigger_topic, Bool, trigger_callback)
 
     publish_visual_output = rospy.get_param('~publish_visual_output', True)
     save_output = rospy.get_param('~save_output', False)
@@ -144,19 +146,21 @@ if __name__ == '__main__':
                       'on the latest message...')
     try:
         while not rospy.is_shutdown():
-            try:
-                rate.sleep()
-            except rospy.ROSTimeMovedBackwardsException as e:
-                rospy.logwarn('[cnn_detector] Caught ROSTimeMovedBackwardsException ' + \
-                              'when executing rate.sleep(). This can happen when ' + \
-                              'incoming messages had stopped, and have just ' + \
-                              'resumed publishing.')
-
             if run_on_trigger:
-                if not triggered_:
-                    continue
-                else:
-                    triggered_ = False
+                # Note: using a signal SIGINT handler here because a try-except
+                # block does not work for the inner while loop (does not terminate cleanly).
+                signal.signal(signal.SIGINT, signal.SIG_DFL);
+                while not triggered_:
+                    rate.sleep()
+                triggered_ = False
+            else:
+                try:
+                    rate.sleep()
+                except rospy.ROSTimeMovedBackwardsException as e:
+                    rospy.logwarn('[cnn_detector] Caught ROSTimeMovedBackwardsException ' + \
+                                  'when executing rate.sleep(). This can happen when ' + \
+                                  'incoming messages had stopped, and have just ' + \
+                                  'resumed publishing.')
 
             rospy.loginfo('[cnn_detector] Running detection model on image...')
             detection_start_time = time.time()

--- a/ros/scripts/continuous_cnn_detector_node
+++ b/ros/scripts/continuous_cnn_detector_node
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+
+"""
+Runs a CNN detector continuously on every incoming image messages and publishes
+the results.
+Optionally runs the detector only after a ROS/UDP trigger message.
+"""
+
+import os
+import sys
+import time
+import pickle
+import datetime
+
+import rospy
+import rospkg
+import cv2
+import torch
+
+from cv_bridge import CvBridge, CvBridgeError
+
+from sensor_msgs.msg import Image
+from eurobin_perception.msg import BoundingBox, BoundingBoxList
+
+from eurobin_perception.image_detection import ImageDetector
+
+supported_torch_devices_ = ['cpu', 'gpu']
+triggered_ = False
+
+## ----------------------------------------------------------------------
+## ROS Callbacks and Message Initializations:
+## ----------------------------------------------------------------------
+
+current_image_msg_ = None
+
+def image_callback(msg):
+    global current_image_msg_
+    current_image_msg_ = msg
+
+
+if __name__ == '__main__':
+    ## ----------------------------------------------------------------------
+    ## ROS Initializations:
+    ## ----------------------------------------------------------------------
+    rospy.init_node('cnn_detector')
+    rate = rospy.Rate(10)
+
+    package_path = rospkg.RosPack().get_path('eurobin_perception')
+
+    model_weights_file_path = rospy.get_param('~model_weights_file_path', '')
+    class_colors_file_path = rospy.get_param('~class_colors_file_path','')
+    dataset_dir_path = rospy.get_param('~dataset_dir_path', '')
+    output_dir_path = rospy.get_param('~output_dir_path', 
+                                      os.path.join(package_path, 'output_data'))
+    confidence_threshold = rospy.get_param('~confidence_threshold', 0.7)
+    run_on_trigger = rospy.get_param('~run_on_trigger', False)
+
+    image_topic = rospy.get_param('~image_topic', '/camera/color/image_raw')
+    image_pub_topic = rospy.get_param('~image_pub_topic', 
+                                      '/eurobin_perception/detection_images')
+    input_image_pub_topic = rospy.get_param('~input_image_pub_topic', 
+                                            '/eurobin_perception/input_images')
+    detection_pub_topic = rospy.get_param('~detection_pub_topic', 
+                                          '/eurobin_perception/detection_result')
+
+    image_subscriber = rospy.Subscriber(image_topic, Image, image_callback)
+
+    publish_visual_output = rospy.get_param('~publish_visual_output', True)
+    save_output = rospy.get_param('~save_output', False)
+
+    device = rospy.get_param('~device', 'cpu')
+
+    bb_publisher = rospy.Publisher(detection_pub_topic, BoundingBoxList, queue_size=10)
+    if publish_visual_output:
+        detection_image_publisher = rospy.Publisher(image_pub_topic, Image, queue_size=10)
+        input_image_publisher = rospy.Publisher(input_image_pub_topic, Image, queue_size=10)
+
+    # Verify device for detection model:
+    if device in supported_torch_devices_:
+        rospy.loginfo('[cnn_detector] Will run model on {}'.format(device))
+    else:
+        rospy.logerr('[cnn_detector] Invalid value for device parameter! Must be one of {}'.format(supported_torch_devices_))
+        sys.exit(1)
+    if device == 'gpu' and not torch.cuda.is_available():
+        rospy.logerr('[cnn_detector] Could not detect gpu device! Terminating.')
+        sys.exit(1)
+
+    # Set up output data directory:
+    if save_output:
+        output_sub_dir_path = 'cnn_detector_output_' + \
+                              datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        output_dir_path = os.path.join(output_dir_path, output_sub_dir_path)
+        rospy.loginfo(f'[cnn_detector] Saving output data in ' + \
+                      f'{output_dir_path}')
+
+        if not os.path.isdir(output_dir_path):
+            rospy.loginfo(f'[cnn_detector] Output directory does not exist! ' + \
+                          f' Creating now...')
+            os.makedirs(output_dir_path)
+
+    bridge = CvBridge()
+
+    ## ----------------------------------------------------------------------
+    ## Detector Initialization:
+    ## ----------------------------------------------------------------------
+
+    rospy.loginfo('[cnn_detector] Initializing ImageDetector...')
+    detector = ImageDetector(dataset_dir_path=dataset_dir_path, 
+                             model_weights_file_path=model_weights_file_path, 
+                             class_colors_file_path=class_colors_file_path, 
+                             confidence_threshold=confidence_threshold,
+                             device=device)
+
+    ## ----------------------------------------------------------------------
+    ## Detector Execution:
+    ## ----------------------------------------------------------------------
+
+    rospy.loginfo(f'[cnn_detector] Subscribing to image topic: {image_topic}')
+    rospy.loginfo('[cnn_detector] Waiting for reception of first image message...')
+    try:
+        while current_image_msg_ is None:
+            rospy.sleep(0.1)
+    except (KeyboardInterrupt, rospy.ROSInterruptException):
+        rospy.loginfo('[cnn_detector] Terminating...')
+        sys.exit(0)
+
+    rospy.loginfo('[cnn_detector] Received first image message')
+
+    if not run_on_trigger:
+        rospy.loginfo('[cnn_detector] Continuously running detection on ' + \
+                      'incoming messages...')
+    else:
+        rospy.loginfo('[cnn_detector] Will run detection at every trigger ' + \
+                      'on the latest message...')
+    try:
+        while not rospy.is_shutdown():
+            try:
+                rate.sleep()
+            except rospy.ROSTimeMovedBackwardsException as e:
+                rospy.logwarn('[cnn_detector] Caught ROSTimeMovedBackwardsException ' + \
+                              'when executing rate.sleep(). This can happen when ' + \
+                              'incoming messages had stopped, and have just ' + \
+                              'resumed publishing.')
+
+            if run_on_trigger:
+                if not triggered_:
+                    continue
+                else:
+                    rospy.loginfo('[cnn_detector] Received trigger message')
+
+            rospy.loginfo('[cnn_detector] Running detection model on image...')
+            detection_start_time = time.time()
+
+            try:
+                image_cv = bridge.imgmsg_to_cv2(current_image_msg_, "bgr8")
+            except CvBridgeError as e:
+                rospy.logwarn('[cnn_detector] Failed to convert image message to' + \
+                              ' opencv format! Skipping...')
+                print('Error:', e)
+                continue
+
+            detector_result = detector.detect_objects(
+                    image_cv, 
+                    return_annotated_image=publish_visual_output or \
+                                           save_output
+            )
+            bboxes = detector_result[0]
+            model_inference_time = detector_result[1]
+            detection_image_cv = detector_result[2]
+            rospy.loginfo(f'[cnn_detector] Model inference time: ' + \
+                          f'{model_inference_time:.2f}s')
+
+            # Publish results in a BoundingBoxList message:
+            bbox_list_msg = BoundingBoxList()
+            for bbox_dict in bboxes:
+                bbox_msg = BoundingBox()
+                bbox_msg.xmin = bbox_dict['xmin']
+                bbox_msg.xmax = bbox_dict['xmax']
+                bbox_msg.ymin = bbox_dict['ymin']
+                bbox_msg.ymax = bbox_dict['ymax']
+                bbox_msg.label = bbox_dict['class']
+                bbox_msg.confidence = bbox_dict['confidence']
+
+                bbox_list_msg.bounding_boxes.append(bbox_msg)
+
+            bb_publisher.publish(bbox_list_msg)
+
+            if publish_visual_output:
+                input_image_msg = bridge.cv2_to_imgmsg(image_cv, encoding="bgr8")
+                input_image_msg.header.stamp = rospy.Time.now()
+                input_image_msg.header.frame_id = current_image_msg_.header.frame_id
+                input_image_publisher.publish(input_image_msg)
+
+                detection_image_msg = bridge.cv2_to_imgmsg(detection_image_cv, 
+                                                           encoding="bgr8")
+                detection_image_msg.header.stamp = rospy.Time.now()
+                detection_image_msg.header.frame_id = current_image_msg_.header.frame_id
+                detection_image_publisher.publish(detection_image_msg)
+
+            detection_time = time.time() - detection_start_time
+            rospy.loginfo(f'[cnn_detector] Finished in {detection_time:.2f}s')
+
+            # Optionally save results: input image, annotated images, and detection
+            # result (bboxes) in a pickle file.
+            if save_output:
+                detection_str = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+                with open(os.path.join(output_dir_path, 
+                                       f'detection_result_{detection_str}.pkl'), 
+                          'wb') as handle:
+                    pickle.dump(bboxes, handle, protocol=pickle.HIGHEST_PROTOCOL)
+                cv2.imwrite(os.path.join(output_dir_path, 
+                                         f'input_image_{detection_str}.png'), 
+                            image_cv)
+                cv2.imwrite(os.path.join(output_dir_path, 
+                                         f'detection_image_{detection_str}.png'), 
+                            detection_image_cv)
+
+    except (KeyboardInterrupt, rospy.ROSInterruptException):
+        rospy.loginfo('[cnn_detector] Stopping node')

--- a/ros/scripts/continuous_cnn_detector_node
+++ b/ros/scripts/continuous_cnn_detector_node
@@ -19,6 +19,7 @@ import torch
 
 from cv_bridge import CvBridge, CvBridgeError
 
+from std_msgs.msg import Bool
 from sensor_msgs.msg import Image
 from eurobin_perception.msg import BoundingBox, BoundingBoxList
 
@@ -36,6 +37,12 @@ current_image_msg_ = None
 def image_callback(msg):
     global current_image_msg_
     current_image_msg_ = msg
+
+def trigger_callback(msg):
+    global triggered_
+
+    rospy.loginfo('[cnn_detector] Received trigger ROS message')
+    triggered_ = msg.data
 
 
 if __name__ == '__main__':
@@ -56,6 +63,8 @@ if __name__ == '__main__':
     run_on_trigger = rospy.get_param('~run_on_trigger', False)
 
     image_topic = rospy.get_param('~image_topic', '/camera/color/image_raw')
+    trigger_topic = rospy.get_param('~trigger_topic', 
+                                    '/eurobin_perception/detector_trigger')
     image_pub_topic = rospy.get_param('~image_pub_topic', 
                                       '/eurobin_perception/detection_images')
     input_image_pub_topic = rospy.get_param('~input_image_pub_topic', 
@@ -64,6 +73,7 @@ if __name__ == '__main__':
                                           '/eurobin_perception/detection_result')
 
     image_subscriber = rospy.Subscriber(image_topic, Image, image_callback)
+    trigger_subscriber = rospy.Subscriber(trigger_topic, Bool, trigger_callback)
 
     publish_visual_output = rospy.get_param('~publish_visual_output', True)
     save_output = rospy.get_param('~save_output', False)
@@ -146,7 +156,7 @@ if __name__ == '__main__':
                 if not triggered_:
                     continue
                 else:
-                    rospy.loginfo('[cnn_detector] Received trigger message')
+                    triggered_ = False
 
             rospy.loginfo('[cnn_detector] Running detection model on image...')
             detection_start_time = time.time()

--- a/ros/scripts/continuous_cnn_detector_node
+++ b/ros/scripts/continuous_cnn_detector_node
@@ -29,7 +29,7 @@ from eurobin_perception.msg import BoundingBox, BoundingBoxList
 from eurobin_perception.image_detection import ImageDetector
 
 supported_torch_devices_ = ['cpu', 'gpu']
-triggered_ = False
+ros_triggered_ = False
 
 ## ----------------------------------------------------------------------
 ## UDP Parameters
@@ -48,10 +48,10 @@ def image_callback(msg):
     current_image_msg_ = msg
 
 def trigger_callback(msg):
-    global triggered_
+    global ros_triggered_
 
     rospy.loginfo('[cnn_detector] Received trigger ROS message')
-    triggered_ = msg.data
+    ros_triggered_ = msg.data
 
 
 if __name__ == '__main__':
@@ -69,7 +69,7 @@ if __name__ == '__main__':
     output_dir_path = rospy.get_param('~output_dir_path', 
                                       os.path.join(package_path, 'output_data'))
     confidence_threshold = rospy.get_param('~confidence_threshold', 0.7)
-    run_on_trigger = rospy.get_param('~run_on_trigger', False)
+    run_on_ros_trigger = rospy.get_param('~run_on_ros_trigger', False)
     run_on_udp_trigger = rospy.get_param('~run_on_udp_trigger', True)
     udp_ip = rospy.get_param('~udp_ip', 'localhost')
     udp_port = rospy.get_param('~udp_port', 8000)
@@ -85,7 +85,7 @@ if __name__ == '__main__':
                                           '/eurobin_perception/detection_result')
 
     image_subscriber = rospy.Subscriber(image_topic, Image, image_callback)
-    if run_on_trigger:
+    if run_on_ros_trigger:
         trigger_subscriber = rospy.Subscriber(trigger_topic, Bool, trigger_callback)
 
     publish_visual_output = rospy.get_param('~publish_visual_output', True)
@@ -109,9 +109,9 @@ if __name__ == '__main__':
         sys.exit(1)
 
     # Verify trigger setting (ROS OR UDP):
-    if run_on_trigger and run_on_udp_trigger:
+    if run_on_ros_trigger and run_on_udp_trigger:
         rospy.logerr('[cnn_detector] Node supports trigger messages from' + \
-                     ' either ROS or UDP, but run_on_trigger and' + \
+                     ' either ROS or UDP, but run_on_ros_trigger and' + \
                      ' run_on_udp_trigger were both set to true!')
         rospy.logerr('[cnn_detector] Terminating.')
         sys.exit(1)
@@ -157,7 +157,7 @@ if __name__ == '__main__':
 
     rospy.loginfo('[cnn_detector] Received first image message')
 
-    if run_on_trigger:
+    if run_on_ros_trigger:
         rospy.loginfo(f'[cnn_detector] Will run detection on the latest '
                       f'image message at every trigger ROS message on ' + \
                       f'on topic {trigger_topic}...')
@@ -175,13 +175,13 @@ if __name__ == '__main__':
 
     try:
         while not rospy.is_shutdown():
-            if run_on_trigger:
+            if run_on_ros_trigger:
                 # Note: using a signal SIGINT handler here because a try-except
                 # block does not work for the inner while loop (does not terminate cleanly).
                 signal.signal(signal.SIGINT, signal.SIG_DFL);
-                while not triggered_:
+                while not ros_triggered_:
                     rate.sleep()
-                triggered_ = False
+                ros_triggered_ = False
             elif run_on_udp_trigger:
                 # Note: the following will block until a message is received:
                 signal.signal(signal.SIGINT, signal.SIG_DFL);

--- a/ros/scripts/continuous_cnn_detector_node
+++ b/ros/scripts/continuous_cnn_detector_node
@@ -9,13 +9,15 @@ Optionally runs the detector only after a ROS/UDP trigger message.
 import os
 import sys
 import time
+import json
 import signal
 import pickle
+import socket
 import datetime
 
+import cv2
 import rospy
 import rospkg
-import cv2
 import torch
 
 from cv_bridge import CvBridge, CvBridgeError
@@ -28,6 +30,12 @@ from eurobin_perception.image_detection import ImageDetector
 
 supported_torch_devices_ = ['cpu', 'gpu']
 triggered_ = False
+
+## ----------------------------------------------------------------------
+## UDP Parameters
+## ----------------------------------------------------------------------
+
+udp_buffer_size_ = 1024
 
 ## ----------------------------------------------------------------------
 ## ROS Callbacks and Message Initializations:
@@ -62,6 +70,9 @@ if __name__ == '__main__':
                                       os.path.join(package_path, 'output_data'))
     confidence_threshold = rospy.get_param('~confidence_threshold', 0.7)
     run_on_trigger = rospy.get_param('~run_on_trigger', False)
+    run_on_udp_trigger = rospy.get_param('~run_on_udp_trigger', True)
+    udp_ip = rospy.get_param('~udp_ip', 'localhost')
+    udp_port = rospy.get_param('~udp_port', 8000)
 
     image_topic = rospy.get_param('~image_topic', '/camera/color/image_raw')
     trigger_topic = rospy.get_param('~trigger_topic', 
@@ -95,6 +106,14 @@ if __name__ == '__main__':
         sys.exit(1)
     if device == 'gpu' and not torch.cuda.is_available():
         rospy.logerr('[cnn_detector] Could not detect gpu device! Terminating.')
+        sys.exit(1)
+
+    # Verify trigger setting (ROS OR UDP):
+    if run_on_trigger and run_on_udp_trigger:
+        rospy.logerr('[cnn_detector] Node supports trigger messages from' + \
+                     ' either ROS or UDP, but run_on_trigger and' + \
+                     ' run_on_udp_trigger were both set to true!')
+        rospy.logerr('[cnn_detector] Terminating.')
         sys.exit(1)
 
     # Set up output data directory:
@@ -138,12 +157,22 @@ if __name__ == '__main__':
 
     rospy.loginfo('[cnn_detector] Received first image message')
 
-    if not run_on_trigger:
-        rospy.loginfo('[cnn_detector] Continuously running detection on ' + \
-                      'incoming messages...')
+    if run_on_trigger:
+        rospy.loginfo(f'[cnn_detector] Will run detection on the latest '
+                      f'image message at every trigger ROS message on ' + \
+                      f'on topic {trigger_topic}...')
+    elif run_on_udp_trigger:
+        rospy.loginfo(f'[cnn_detector] Will run detection on the latest '
+                      f'image message at every trigger UDP message on ' + \
+                      f' over IP {udp_ip} and port {udp_port}...')
+
+        udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        udp_socket.settimeout(None)
+        udp_socket.bind((udp_ip, udp_port))
     else:
-        rospy.loginfo('[cnn_detector] Will run detection at every trigger ' + \
-                      'on the latest message...')
+        rospy.loginfo('[cnn_detector] Continuously running detection on ' + \
+                      'incoming image messages...')
+
     try:
         while not rospy.is_shutdown():
             if run_on_trigger:
@@ -153,6 +182,27 @@ if __name__ == '__main__':
                 while not triggered_:
                     rate.sleep()
                 triggered_ = False
+            elif run_on_udp_trigger:
+                # Note: the following will block until a message is received:
+                signal.signal(signal.SIGINT, signal.SIG_DFL);
+                udp_msg, udp_addr = udp_socket.recvfrom(udp_buffer_size_)
+
+                rospy.loginfo('[cnn_detector] Received trigger UDP message')
+                udp_msg_data = json.loads(udp_msg.decode())
+
+                try:
+                    if type(udp_msg_data["trigger"]).__name__ != 'bool' or \
+                            udp_msg_data['trigger'] != True:
+                        rospy.logwarn('[cnn_detector] Received invalid value' + \
+                                      ' in UDP message dict for key trigger:' + \
+                                     f' {udp_msg_data["trigger"]}. Will only' + \
+                                      ' trigger on "True". Ignoring... ')
+                        continue
+                except Exception as e:
+                    rospy.logwarn('[cnn_detector] Could not access trigger' + \
+                                  ' information in UDP message! Please check' + \
+                                 f' message format!. Ignoring...')
+                    continue
             else:
                 try:
                     rate.sleep()

--- a/ros/scripts/continuous_cnn_detector_node
+++ b/ros/scripts/continuous_cnn_detector_node
@@ -72,7 +72,7 @@ if __name__ == '__main__':
     run_on_ros_trigger = rospy.get_param('~run_on_ros_trigger', False)
     run_on_udp_trigger = rospy.get_param('~run_on_udp_trigger', True)
     udp_ip = rospy.get_param('~udp_ip', 'localhost')
-    udp_port = rospy.get_param('~udp_port', 8000)
+    udp_trigger_port = rospy.get_param('~udp_trigger_port', 5000)
 
     image_topic = rospy.get_param('~image_topic', '/camera/color/image_raw')
     trigger_topic = rospy.get_param('~trigger_topic', 
@@ -164,11 +164,11 @@ if __name__ == '__main__':
     elif run_on_udp_trigger:
         rospy.loginfo(f'[cnn_detector] Will run detection on the latest '
                       f'image message at every trigger UDP message on ' + \
-                      f' over IP {udp_ip} and port {udp_port}...')
+                      f' over IP {udp_ip} and port {udp_trigger_port}...')
 
-        udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        udp_socket.settimeout(None)
-        udp_socket.bind((udp_ip, udp_port))
+        udp_trigger_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        udp_trigger_socket.settimeout(None)
+        udp_trigger_socket.bind((udp_ip, udp_trigger_port))
     else:
         rospy.loginfo('[cnn_detector] Continuously running detection on ' + \
                       'incoming image messages...')
@@ -185,14 +185,14 @@ if __name__ == '__main__':
             elif run_on_udp_trigger:
                 # Note: the following will block until a message is received:
                 signal.signal(signal.SIGINT, signal.SIG_DFL);
-                udp_msg, udp_addr = udp_socket.recvfrom(udp_buffer_size_)
+                udp_msg, udp_addr = udp_trigger_socket.recvfrom(udp_buffer_size_)
 
                 rospy.loginfo('[cnn_detector] Received trigger UDP message')
                 udp_msg_data = json.loads(udp_msg.decode())
 
                 try:
-                    if type(udp_msg_data["trigger"]).__name__ != 'bool' or \
-                            udp_msg_data['trigger'] != True:
+                    if type(udp_msg_data['trigger']).__name__ != 'str' or \
+                            udp_msg_data['trigger'] != "True":
                         rospy.logwarn('[cnn_detector] Received invalid value' + \
                                       ' in UDP message dict for key trigger:' + \
                                      f' {udp_msg_data["trigger"]}. Will only' + \

--- a/ros/scripts/pose_estimator_node
+++ b/ros/scripts/pose_estimator_node
@@ -72,13 +72,6 @@ def camera_info_callback(msg):
 object_marker_publisher_ = None
 
 ## ----------------------------------------------------------------------
-## UDP Parameters
-## ----------------------------------------------------------------------
-
-udp_ip_ = '127.0.0.1'
-udp_port_ = 9000
-
-## ----------------------------------------------------------------------
 ## Functions:
 ## ----------------------------------------------------------------------
 
@@ -174,6 +167,8 @@ if __name__ == '__main__':
                                       os.path.join(package_path, 'output_data'))
     taskboard_frame_name = rospy.get_param('~taskboard_frame_name', 'taskboard_frame')
     num_retries = rospy.get_param('~num_retries', 3)
+    udp_ip = rospy.get_param('~udp_ip', 'localhost')
+    udp_output_port = rospy.get_param('~udp_output_port', 6000)
 
     pointcloud_topic = rospy.get_param('~pointcloud_topic', '/camera/depth/color/points')
     camera_info_topic = rospy.get_param('~camera_info_topic', '/camera/color/camera_info')
@@ -201,9 +196,9 @@ if __name__ == '__main__':
 
     rospy.loginfo(f'[pose_estimator] Initializing UDP socket with address' + \
                   f' family AF_INET and type SOCK_DGRAM')
-    rospy.loginfo(f'[pose_estimator] Will send messages over IP {udp_ip_}' + \
-                  f' and port {udp_port_}.')
-    udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    rospy.loginfo(f'[pose_estimator] Will send messages over IP {udp_ip}' + \
+                  f' and port {udp_output_port}.')
+    udp_output_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
     ## ----------------------------------------------------------------------
     ## Estimator Execution:
@@ -728,7 +723,7 @@ if __name__ == '__main__':
                 if debug:
                     print(f'[DEBUG] UDP message: \n{udp_message}')
                 udp_message = udp_message.encode()
-                udp_socket.sendto(udp_message, (udp_ip_, udp_port_))
+                udp_output_socket.sendto(udp_message, (udp_ip, udp_output_port))
 
             rate.sleep()
     except (KeyboardInterrupt, rospy.ROSInterruptException):

--- a/ros/scripts/pose_estimator_node
+++ b/ros/scripts/pose_estimator_node
@@ -173,7 +173,8 @@ if __name__ == '__main__':
     pointcloud_topic = rospy.get_param('~pointcloud_topic', '/camera/depth/color/points')
     camera_info_topic = rospy.get_param('~camera_info_topic', '/camera/color/camera_info')
     detector_result_topic = rospy.get_param('~detector_result_topic', '/eurobin_perception/detection_result')
-    object_list_pub_topic = rospy.get_param('~object_list_pub_topic', '/eurobin_perception/object_positions')
+    object_positions_pub_topic = rospy.get_param('~object_positions_pub_topic', '/eurobin_perception/object_positions')
+    object_poses_pub_topic = rospy.get_param('~object_poses_pub_topic', '/eurobin_perception/object_poses')
     object_marker_pub_topic = rospy.get_param('~object_marker_pub_topic', '/eurobin_perception/object_markers')
     cropped_pc_pub_topic = rospy.get_param('~cropped_pc_pub_topic', '/eurobin_perception/cropped_pc')
 
@@ -184,7 +185,8 @@ if __name__ == '__main__':
     detector_result_subscriber = rospy.Subscriber(detector_result_topic, BoundingBoxList, detection_callback)
     camera_info_subscriber = rospy.Subscriber(camera_info_topic, CameraInfo, camera_info_callback)
 
-    object_list_publisher = rospy.Publisher(object_list_pub_topic, ObjectList, queue_size=10)
+    object_positions_publisher = rospy.Publisher(object_positions_pub_topic, ObjectList, queue_size=10)
+    object_poses_publisher = rospy.Publisher(object_poses_pub_topic, ObjectList, queue_size=10)
     object_marker_publisher_ = rospy.Publisher(object_marker_pub_topic, MarkerArray, queue_size=10)
     cropped_pc_debug_publisher = rospy.Publisher(cropped_pc_pub_topic, PointCloud, queue_size=10)
 
@@ -285,7 +287,7 @@ if __name__ == '__main__':
                         marker_array_msg.markers.append(marker_msg)
                         marker_array_msg.markers.append(text_marker_msg)
 
-                    object_list_publisher.publish(object_list_msg)
+                    object_positions_publisher.publish(object_list_msg)
                     object_marker_publisher_.publish(marker_array_msg)
 
                     cropped_pc_debug_publisher.publish(cropped_pc_msg)
@@ -712,7 +714,7 @@ if __name__ == '__main__':
                         tf_msg.transform.rotation = tb_quaternion
                         tf_broadcaster.sendTransform(tf_msg)
 
-                    object_list_publisher.publish(updated_object_list_msg)
+                    object_poses_publisher.publish(updated_object_list_msg)
 
                     udp_object_list_msg = updated_object_list_msg
                 else:

--- a/ros/scripts/pose_estimator_node
+++ b/ros/scripts/pose_estimator_node
@@ -243,7 +243,12 @@ if __name__ == '__main__':
                     object_points_dict = convert_object_points_to_arrays(object_points_dict)
 
                     # Copy unfiltered taskboard data for later visualizations:
-                    unfiltered_points_array = object_points_dict['taskboard'].copy()
+                    try:
+                        unfiltered_points_array = object_points_dict['taskboard'].copy()
+                    except KeyError:
+                        rospy.logwarn('[pose_estimator] Did not find taskboard in detection result message!')
+                        rospy.logwarn('[pose_estimator] Skipping pose estimation...')
+                        continue
 
                     # Remove outliers using IQR method:
                     for object_id, points_array in object_points_dict.items():
@@ -404,7 +409,7 @@ if __name__ == '__main__':
                         if quadrant_corner_ids['4'] == None or \
                                 quadrant_corner_ids['4'] == quadrant_corner_ids['1'] or \
                                 quadrant_corner_ids['4'] == quadrant_corner_ids['2']:
-                            rospy.logerr('[pose_estimator] Using test heuristic to determine quadrant 4...')
+                            rospy.logwarn('[pose_estimator] Using test heuristic to determine quadrant 4...')
                             q1_coordinates = rect_rectified_corners[quadrant_corner_ids['1']]
                             q2_coordinates = rect_rectified_corners[quadrant_corner_ids['2']]
                             corner_distances = np.linalg.norm(rect_rectified_corners - q1_coordinates, axis=1)

--- a/src/eurobin_perception/image_detection.py
+++ b/src/eurobin_perception/image_detection.py
@@ -54,7 +54,7 @@ class ImageDetector(object):
         """
         print(f'[INFO] [{self.name}] Loading pretrained Faster R-CNN model' + \
               f' from: {self.model_weights_file_path}')
-        self.model = get_tb_cnn_model()
+        self.model = get_tb_cnn_model(self.dataset.get_num_classes())
         self.model.load_state_dict(torch.load(self.model_weights_file_path, 
                                               map_location=self.device))
         self.model.eval()

--- a/src/eurobin_perception/models.py
+++ b/src/eurobin_perception/models.py
@@ -8,24 +8,21 @@ import torchvision
 
 from eurobin_perception.dataset import TaskboardDataset
 
-tb_dataset_path_ = '/home/ahmed/tum/workspace/euRobin/detection_task/dataset'
-
-def get_tb_cnn_model():
+def get_tb_cnn_model(num_classes):
     """
     Initializes and returns a FastRCNN CNN model that is configured for the
     number of classes in the taskboard dataset.
 
     Parameters
     ----------
-    None
+    num_classes: int
+        Number of classes that the model should expect
 
     Returns
     -------
     model: torchvision.models.detection.faster_rcnn.FasterRCNN
         FasterRCNN model object
     """
-    tb_dataset = TaskboardDataset(root=tb_dataset_path_)
-    num_classes = tb_dataset.get_num_classes()
 
     model = torchvision.models.detection.fasterrcnn_resnet50_fpn(weights="DEFAULT")
     in_features = model.roi_heads.box_predictor.cls_score.in_features

--- a/src/eurobin_perception/pose_estimation.py
+++ b/src/eurobin_perception/pose_estimation.py
@@ -222,7 +222,12 @@ def convert_object_points_to_arrays(point_lists_dict):
     """
     point_arrays_dict = {}
     for label in point_lists_dict.keys():
-        point_arrays_dict[label] = np.stack(point_lists_dict[label])
+        try:
+            point_arrays_dict[label] = np.stack(point_lists_dict[label])
+        except ValueError:
+            print(f'[pose_estimator] [WARN] No points to extract for label {label}!')
+            print(f'[pose_estimator] [WARN] Skipping label {label}...')
+            continue
 
     return point_arrays_dict 
 


### PR DESCRIPTION
## Description

This PR mainly add features and modifications that are intended to address the requirements of the upcoming eurobin demo.

Changes include:
* Making a continuous version of the `single_cnn_detector_node`: `continuous_cnn_detector_node `, which can either be always active i.e. processing all incoming messages and running the detector, or inactive until triggered.
* Ability to trigger the `continuous_cnn_detector_node` through a UDP message containing the following JSON dict:
```
{
    "trigger": "True"
}
```
* Ability to trigger the node using a ROS `Bool` message.

## TODOs

- [x] Refine sending of `pose_estimator` outputs through UDP (make port configurable, etc.)