### PR TITLE
Fix: Remove Dependence on Dataset Files

### DIFF
--- a/config/labels.txt
+++ b/config/labels.txt
@@ -1,0 +1,12 @@
+background
+taskboard
+red_button
+blue_button
+lcd
+slider
+hatch_handle
+multimeter_connector
+multimeter_probe
+multimeter_socket
+wire_connector
+cable_holder

--- a/ros/launch/object_detector.launch
+++ b/ros/launch/object_detector.launch
@@ -3,7 +3,7 @@
 
     <arg name="model_weights_file_path" default="$(find eurobin_perception)/models/tb_fasterrcnn_epochs_25_batches_1_tv_ratio_07_seed_2_20240121_154144.pt"/>
     <arg name="class_colors_file_path" default="$(find eurobin_perception)/config/class_colors_taskboard.yaml"/>
-    <arg name="dataset_dir_path" default="/home/ahmed/tum/workspace/euRobin/detection_task/dataset"/>
+    <arg name="labels_file_path" default="$(find eurobin_perception)/config/labels.txt"/>
     <!-- <arg name="output_dir_path" default="$(find eurobin_perception)/output_data"/> -->
     <arg name="output_dir_path" default="/tmp"/>
     <arg name="confidence_threshold" default="0.7"/>
@@ -24,7 +24,7 @@
         output="screen" respawn="false">
         <param name="model_weights_file_path" type="str" value="$(arg model_weights_file_path)"/>
         <param name="class_colors_file_path" type="str" value="$(arg class_colors_file_path)"/>
-        <param name="dataset_dir_path" type="str" value="$(arg dataset_dir_path)"/>
+        <param name="labels_file_path" type="str" value="$(arg labels_file_path)"/>
         <param name="output_dir_path" type="str" value="$(arg output_dir_path)"/>
         <param name="confidence_threshold" type="double" value="$(arg confidence_threshold)"/>
         <param name="run_on_ros_trigger" type="bool" value="$(arg run_on_ros_trigger)"/>

--- a/ros/launch/object_detector_single.launch
+++ b/ros/launch/object_detector_single.launch
@@ -3,7 +3,7 @@
 
     <arg name="model_weights_file_path" default="$(find eurobin_perception)/models/tb_fasterrcnn_epochs_25_batches_1_tv_ratio_07_seed_2_20240121_154144.pt"/>
     <arg name="class_colors_file_path" default="$(find eurobin_perception)/config/class_colors_taskboard.yaml"/>
-    <arg name="dataset_dir_path" default="/home/ahmed/tum/workspace/euRobin/detection_task/dataset"/>
+    <arg name="labels_file_path" default="$(find eurobin_perception)/config/labels.txt"/>
     <arg name="output_dir_path" default="$(find eurobin_perception)/output_data"/>
     <arg name="confidence_threshold" default="0.7"/>
     <arg name="image_topic" default="/camera/color/image_raw"/>
@@ -19,7 +19,7 @@
         output="screen" respawn="false">
         <param name="model_weights_file_path" type="str" value="$(arg model_weights_file_path)"/>
         <param name="class_colors_file_path" type="str" value="$(arg class_colors_file_path)"/>
-        <param name="dataset_dir_path" type="str" value="$(arg dataset_dir_path)"/>
+        <param name="labels_file_path" type="str" value="$(arg labels_file_path)"/>
         <param name="output_dir_path" type="str" value="$(arg output_dir_path)"/>
         <param name="confidence_threshold" type="double" value="$(arg confidence_threshold)"/>
         <param name="image_topic" type="str" value="$(arg image_topic)"/>

--- a/ros/scripts/continuous_cnn_detector_node
+++ b/ros/scripts/continuous_cnn_detector_node
@@ -65,7 +65,7 @@ if __name__ == '__main__':
 
     model_weights_file_path = rospy.get_param('~model_weights_file_path', '')
     class_colors_file_path = rospy.get_param('~class_colors_file_path','')
-    dataset_dir_path = rospy.get_param('~dataset_dir_path', '')
+    labels_file_path = rospy.get_param('~labels_file_path', '')
     output_dir_path = rospy.get_param('~output_dir_path', 
                                       os.path.join(package_path, 'output_data'))
     confidence_threshold = rospy.get_param('~confidence_threshold', 0.7)
@@ -136,8 +136,8 @@ if __name__ == '__main__':
     ## ----------------------------------------------------------------------
 
     rospy.loginfo('[cnn_detector] Initializing ImageDetector...')
-    detector = ImageDetector(dataset_dir_path=dataset_dir_path, 
-                             model_weights_file_path=model_weights_file_path, 
+    detector = ImageDetector(model_weights_file_path=model_weights_file_path, 
+                             labels_file_path=labels_file_path,
                              class_colors_file_path=class_colors_file_path, 
                              confidence_threshold=confidence_threshold,
                              device=device)

--- a/ros/scripts/single_cnn_detector_node
+++ b/ros/scripts/single_cnn_detector_node
@@ -35,7 +35,7 @@ if __name__ == '__main__':
 
     model_weights_file_path = rospy.get_param('~model_weights_file_path', '')
     class_colors_file_path = rospy.get_param('~class_colors_file_path','')
-    dataset_dir_path = rospy.get_param('~dataset_dir_path', '')
+    labels_file_path = rospy.get_param('~labels_file_path', '')
     output_dir_path = rospy.get_param('~output_dir_path', 
                                       os.path.join(package_path, 'output_data'))
     confidence_threshold = rospy.get_param('~confidence_threshold', 0.7)
@@ -76,8 +76,8 @@ if __name__ == '__main__':
     ## ----------------------------------------------------------------------
 
     rospy.loginfo('[single_cnn_detector] Initializing ImageDetector...')
-    detector = ImageDetector(dataset_dir_path=dataset_dir_path, 
-                             model_weights_file_path=model_weights_file_path, 
+    detector = ImageDetector(model_weights_file_path=model_weights_file_path, 
+                             labels_file_path=labels_file_path,
                              class_colors_file_path=class_colors_file_path, 
                              confidence_threshold=confidence_threshold,
                              device=device)

--- a/src/eurobin_perception/dataset.py
+++ b/src/eurobin_perception/dataset.py
@@ -61,6 +61,29 @@ def load_xml_labels(filepath):
 
     return image_id, bboxes
 
+        
+def load_labels(labels_file_path, remove_bg=False):
+    """
+    Loads and stores the list of labels.
+
+    Parameters
+    ----------
+    remove_bg: bool
+        Whether to exclude the "background" class from the list.
+
+    Returns
+    -------
+    labels_list: list
+        Strings representing each class.
+    """
+    with open(labels_file_path, 'r') as filehandle:
+        labels_list = filehandle.read().splitlines()
+
+    if remove_bg:
+        labels_list.remove('background')
+
+    return labels_list
+
 def get_bboxes_array(bboxes_list):
     """
     Aggregates bbox coordinates in a single numpy array.
@@ -179,11 +202,11 @@ class TaskboardDataset(torch.utils.data.Dataset):
                                 'high_light': 'light_on'}
         self.imgs = []
         self.labels = []
-        self.gt_labels_list = None
-        self.num_classes = None
 
         self.load_img_and_label_filenames()
         self.load_labels()
+        self.gt_labels_list = load_labels(os.path.join(self.root, 'labels.txt'))
+        self.num_classes = len(self.gt_labels_list)
 
         self.transforms = apply_transforms(training)
         
@@ -217,29 +240,7 @@ class TaskboardDataset(torch.utils.data.Dataset):
             
             self.imgs.extend(img_filenames)
             self.labels.extend(label_filenames)
-        
-    def load_labels(self, remove_bg=False):
-        """
-        Loads and stores the list of labels.
 
-        Parameters
-        ----------
-        remove_bg: bool
-            Whether to exclude the "background" class from the list.
-
-        Returns
-        -------
-        None
-        """
-        labels_file_path = os.path.join(self.root, 'labels.txt')
-        with open(labels_file_path, 'r') as filehandle:
-            self.gt_labels_list = filehandle.read().splitlines()
-
-        if remove_bg:
-            self.gt_labels_list.remove('background')
-
-        self.num_classes = len(self.gt_labels_list)
-        
     def get_labels_list(self):
         """
         Returns the labels list.

--- a/src/eurobin_perception/image_detection.py
+++ b/src/eurobin_perception/image_detection.py
@@ -12,7 +12,7 @@ import torch
 from torchvision import tv_tensors
 
 from eurobin_perception.models import get_tb_cnn_model
-from eurobin_perception.dataset import TaskboardDataset, apply_transforms
+from eurobin_perception.dataset import apply_transforms, load_labels
 from eurobin_perception.utils import get_bbox_dicts, filter_preds
 from eurobin_perception.visualization import load_class_color_map, annotate_image
 
@@ -25,15 +25,15 @@ class ImageDetector(object):
     challenge and dataset, but could be made more general in the future.
     """
 
-    def __init__(self, dataset_dir_path, model_weights_file_path, 
+    def __init__(self, model_weights_file_path, labels_file_path,
                  class_colors_file_path, confidence_threshold,
                  device='cpu'):
         self.model_weights_file_path = model_weights_file_path
         self.confidence_threshold = confidence_threshold
         self.device = device
 
-        self.dataset = TaskboardDataset(root=dataset_dir_path)
-        self.labels_list = self.dataset.get_labels_list()
+        self.labels_list = load_labels(labels_file_path)
+        self.num_classes = len(self.labels_list)
         self.class_colors_dict = load_class_color_map(class_colors_file_path)
         self.tensor_transforms = apply_transforms()
 
@@ -54,7 +54,7 @@ class ImageDetector(object):
         """
         print(f'[INFO] [{self.name}] Loading pretrained Faster R-CNN model' + \
               f' from: {self.model_weights_file_path}')
-        self.model = get_tb_cnn_model(self.dataset.get_num_classes())
+        self.model = get_tb_cnn_model(self.num_classes)
         self.model.load_state_dict(torch.load(self.model_weights_file_path, 
                                               map_location=self.device))
         self.model.eval()


### PR DESCRIPTION
## Description

This PR removes the requirement for having the dataset directory to run the object detector. The dataset directory is required in the  `TaskboardDataset` class, which was previously imported in `image_detection.py` only to retrieve the list of labels. Now, the labels are included in the `config` directory in the repository.