### PR TITLE
Fix: Confidence Score on Annotated Images

### DIFF
--- a/src/tum_tb_perception/visualization.py
+++ b/src/tum_tb_perception/visualization.py
@@ -114,10 +114,10 @@ def annotate_image(image, bboxes, class_colors_dict, target_bboxes=None,
                                         color=color, thickness=2)
 
         # Construct label text:
-        confidence = bbox['confidence']
+        confidence = float(bbox['confidence'])
         label_str = label
         if confidence is not None:
-            label_str += ': {:.2f}%'.format(float(confidence))
+            label_str += ': {:d}%'.format(int(confidence * 100.))
 
         # Estimate area of label box:
         (w, h), _ = cv2.getTextSize(label_str, cv2_bbox_font_,


### PR DESCRIPTION
## Description

This PR fixes the confidence scores that are displayed on annotated CNN detection images (e.g. 0.9% --> 90%)