### PR TITLE
Fix: Add scikit-learn Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ tum-tb-perception
 * `rospy`
 * `rospkg`
 * `scipy`
+* `scikit-learn`
 * `torch`
 * `torchvision`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ numpy==1.24.4
 opencv_python==4.9.0.80
 pandas==2.0.3
 PyYAML==5.3.1
+scikit-learn==1.3.2
 scipy==1.10.1
 setuptools==69.0.3
 torch==2.1.0


### PR DESCRIPTION
## Description

This PR implements adds a missing dependency to the `requirements.txt` and `README.md`: `scikit-learn`