### PR TITLE
GPU support minor mods

### DIFF
--- a/ros/scripts/continuous_cnn_detector_node
+++ b/ros/scripts/continuous_cnn_detector_node
@@ -107,6 +107,8 @@ if __name__ == '__main__':
     if device == 'gpu' and not torch.cuda.is_available():
         rospy.logerr('[cnn_detector] Could not detect gpu device! Terminating.')
         sys.exit(1)
+    if device == 'gpu':
+        device = 'cuda:0' # 'gpu' is invalid as torch device. Take first available GPU.
 
     # Verify trigger setting (ROS OR UDP):
     if run_on_ros_trigger and run_on_udp_trigger:

--- a/src/tum_tb_perception/image_detection.py
+++ b/src/tum_tb_perception/image_detection.py
@@ -57,6 +57,7 @@ class ImageDetector(object):
         self.model = get_tb_cnn_model(self.num_classes)
         self.model.load_state_dict(torch.load(self.model_weights_file_path, 
                                               map_location=self.device))
+        self.model.to(self.device)
         self.model.eval()
 
     def detect_objects(self, image_cv, return_annotated_image=True):


### PR DESCRIPTION
- Convert "gpu" option to "cuda:0" so model can be loaded on GPU.
- move model to gpu explicitly (currently weights apparently remain on CPU despite device being specified in line
self.model.load_state_dict(torch.load(self.model_weights_file_path, 
                                              map_location=self.device))
