### PR TITLE
Fix: Point Cloud Outlier Removal

### DIFF
--- a/ros/tum_tb_perception/pose_estimator_node.py
+++ b/ros/tum_tb_perception/pose_estimator_node.py
@@ -489,6 +489,8 @@ class PoseEstimatorNode(Node):
                                       'plot_fitted_rectified_rectangle': True, 
                                       'hide_pc_points': False}
 
+                        self.get_logger().info(f'Estimating detected object orientations...')
+
                         # Run orientation estimation until successful for a maximum of num_retries times.
                         for attempt_id in range(self.num_retries):
                             tb_orientation_estimation_start_time = time.time()

--- a/ros/tum_tb_perception/pose_estimator_node.py
+++ b/ros/tum_tb_perception/pose_estimator_node.py
@@ -44,6 +44,11 @@ from tum_tb_perception.utils import bbox_list_msg_to_list, obj_list_msg_to_json
 from tum_tb_perception.visualization import load_class_color_map
 from tum_tb_perception.dataset import load_labels
 
+# The following fixes an occasional visualization issue in Ubuntu 22.04
+# if running with the debug flag:
+if 'QT_QPA_PLATFORM_PLUGIN_PATH' in os.environ.keys():
+    os.environ.pop("QT_QPA_PLATFORM_PLUGIN_PATH")
+
 
 ## ----------------------------------------------------------------------
 ## ROS Nodes, Callbacks and Message Initializations:

--- a/tum_tb_perception/pose_estimation.py
+++ b/tum_tb_perception/pose_estimation.py
@@ -159,7 +159,7 @@ class PositionEstimator(object):
             if debug:
                 print(f'\n[DEBUG] [{self.name}] Removing outliers from {object_id} points...')
 
-            percentiles = (35, 65) if object_id == 'taskboard' else (25, 75)
+            percentiles = (25, 75)
             filtered_points_array = self.remove_outliers(points_array,
                                                          percentiles=percentiles,
                                                          debug=debug)


### PR DESCRIPTION
## Description

This PR mainly fixes the point cloud outlier removal in the pose estimation pipeline due to a degradation in results following the object detector label color fix in https://github.com/eurobin-wp1/tum-tb-perception/pull/22. The reparamaterization of the filters leads to more reliable pose estimation results.