### PR TITLE
Fix: Object Detector GPU Usage

### DIFF
--- a/ros/tum_tb_perception/continuous_cnn_detector_node.py
+++ b/ros/tum_tb_perception/continuous_cnn_detector_node.py
@@ -32,7 +32,7 @@ from tum_tb_perception_msgs.msg import BoundingBox, BoundingBoxList
 
 from tum_tb_perception.image_detection import ImageDetector
 
-supported_torch_devices_ = ['cpu', 'gpu']
+supported_torch_devices_ = ['cpu', 'cuda']
 
 ## ----------------------------------------------------------------------
 ## UDP Parameters

--- a/tum_tb_perception/image_detection.py
+++ b/tum_tb_perception/image_detection.py
@@ -54,7 +54,7 @@ class ImageDetector(object):
         """
         print(f'[INFO] [{self.name}] Loading pretrained Faster R-CNN model' + \
               f' from: {self.model_weights_file_path}')
-        self.model = get_tb_cnn_model(self.num_classes)
+        self.model = get_tb_cnn_model(self.num_classes).to(self.device)
         self.model.load_state_dict(torch.load(self.model_weights_file_path, 
                                               map_location=self.device))
         self.model.eval()


### PR DESCRIPTION
## Description

This PR fixes bugs that prevented the object detector from utilizing a GPU device:
- Incorrect `torch` device string: `gpu` --> `cuda`
- Not loading the model on the `cuda` device just after calling `get_tb_cnn_model`