### PR TITLE
Fix: Object Detector GPU Usage (noetic)

### DIFF
--- a/ros/scripts/continuous_cnn_detector_node
+++ b/ros/scripts/continuous_cnn_detector_node
@@ -28,7 +28,7 @@ from tum_tb_perception.msg import BoundingBox, BoundingBoxList
 
 from tum_tb_perception.image_detection import ImageDetector
 
-supported_torch_devices_ = ['cpu', 'gpu']
+supported_torch_devices_ = ['cpu', 'cuda']
 ros_triggered_ = False
 
 ## ----------------------------------------------------------------------
@@ -104,7 +104,7 @@ if __name__ == '__main__':
     else:
         rospy.logerr('[cnn_detector] Invalid value for device parameter! Must be one of {}'.format(supported_torch_devices_))
         sys.exit(1)
-    if device == 'gpu' and not torch.cuda.is_available():
+    if device == 'cuda' and not torch.cuda.is_available():
         rospy.logerr('[cnn_detector] Could not detect gpu device! Terminating.')
         sys.exit(1)
     if device == 'gpu':

--- a/ros/scripts/continuous_cnn_detector_node
+++ b/ros/scripts/continuous_cnn_detector_node
@@ -107,8 +107,6 @@ if __name__ == '__main__':
     if device == 'cuda' and not torch.cuda.is_available():
         rospy.logerr('[cnn_detector] Could not detect gpu device! Terminating.')
         sys.exit(1)
-    if device == 'gpu':
-        device = 'cuda:0' # 'gpu' is invalid as torch device. Take first available GPU.
 
     # Verify trigger setting (ROS OR UDP):
     if run_on_ros_trigger and run_on_udp_trigger:


### PR DESCRIPTION
## Description

This PR fixes bugs that prevented the object detector from utilizing a GPU device:
- Incorrect `torch` device string: `gpu` --> `cuda`
- Removing now obsolete gpu string check introduced in https://github.com/eurobin-wp1/tum-tb-perception/pull/19